### PR TITLE
NSDS-1951: Support deployment of both CentOS and OracleLinux Versions of Core

### DIFF
--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
-if [ "$#" -ne 1 ]; then
-  echo "Enter tag as arg: $0 <tag>"
-  echo "e.g.: $0 20170620"
-  echo "e.g.: $0 latest"
+if [ "$#" -ne 7 ]; then
+  echo "Usage: $0 <tag> <github org> <github repo branch> <framework branch> <hysds release> <base image tag> <base branch>"
+  echo "e.g.: $0 20170620 hysds master develop v4.0.1-beta.7 latest develop"
+  echo "e.g.: $0 latest pymonger develop develop develop develop master"
   exit 1
 fi
 TAG=$1
-
+ORG=$2
+BRANCH=$3
+FRAMEWORK_BRANCH=$4
+HYSDS_RELEASE=$5
+BASE_IMAGE_TAG=$6
+BASE_BRANCH=$7
 
 # enable docker buildkit to allow build secrets
 export DOCKER_BUILDKIT=1
@@ -20,7 +25,13 @@ fi
  
  
 # build
-docker system prune -f || :
 docker build --progress=plain --rm --force-rm \
-  -t hysds/cont_int:${TAG} -f docker/Dockerfile --build-arg RELEASE=${TAG} \
+  -t hysds/cont_int:${TAG} -f docker/Dockerfile \
+  --build-arg FRAMEWORK_BRANCH=${FRAMEWORK_BRANCH} \
+  --build-arg HYSDS_RELEASE=${HYSDS_RELEASE} \
+  --build-arg TAG=${BASE_IMAGE_TAG} \
+  --build-arg ORG=${ORG} \
+  --build-arg BRANCH=${BRANCH} \
+  --build-arg BASE_BRANCH=${BASE_BRANCH} \
   --secret id=git_oauth_token,src=$OAUTH_CFG . || exit 1
+docker system prune -f || :

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,21 @@
 # syntax = docker/dockerfile:1.0-experimental
-FROM hysds/dev:latest
+ARG TAG=latest
+FROM hysds/dev:${TAG}
+
+# get org and branch
+ARG ORG
+ARG BRANCH
+ARG FRAMEWORK_BRANCH
+ARG BASE_BRANCH
 
 # git url to hysds dev puppet module
-ENV GIT_URL https://github.com/hysds/puppet-cont_int/raw/docker/install.sh
+ENV GIT_URL https://github.com/${ORG}/puppet-cont_int/raw/${BRANCH}/install.sh
 
 # get release to install
-ARG RELEASE=develop
+ARG HYSDS_RELEASE=develop
 
 # add latest repo version to invalidate cache
-ADD https://api.github.com/repos/hysds/puppet-cont_int/git/refs/heads/docker version.json
+ADD https://api.github.com/repos/${ORG}/puppet-cont_int/git/refs/heads/${BRANCH} version.json
 
 # provision via puppet
 RUN --mount=type=secret,id=git_oauth_token sudo cp /run/secrets/git_oauth_token $HOME/.git_oauth_token \
@@ -17,32 +24,37 @@ RUN --mount=type=secret,id=git_oauth_token sudo cp /run/secrets/git_oauth_token 
  && sudo yum update -y \
  && sudo curl -skL ${GIT_URL} > /tmp/install.sh \
  && sudo chmod 755 /tmp/install.sh \
- && sudo /tmp/install.sh \
+ && sudo /tmp/install.sh ${ORG} ${BRANCH} ${BASE_BRANCH} \
  && sudo rm -rf /etc/puppet/modules/* /mnt/swapfile \
  && sudo yum clean all \
  && sudo rm -f /tmp/install.sh \
  && sudo rm -rf /var/cache/yum \
  && cd $HOME \
- && ./install_hysds.sh ${RELEASE} \
+ && ./install_hysds.sh ${FRAMEWORK_BRANCH} ${HYSDS_RELEASE} \
  && rm -rf $HOME/verdi/ops/*/.git* \
  && rm -rf $HOME/.cache \
  && rm -rf $HOME/.git_oauth_token
 
 
-FROM hysds/base:latest
+FROM hysds/base:${TAG}
 
 MAINTAINER Gerald Manipon (pymonger) "pymonger@gmail.com"
 LABEL description="HySDS continous integration image"
 
+# get org and branch
+ARG ORG
+ARG BRANCH
+ARG BASE_BRANCH
+
 # git url to hysds dev puppet module
-ENV GIT_URL https://github.com/hysds/puppet-cont_int/raw/docker/install.sh
+ENV GIT_URL https://github.com/${ORG}/puppet-cont_int/raw/${BRANCH}/install.sh
 
 # provision via puppet
 RUN set -ex \
  && sudo yum update -y \
  && sudo curl -skL ${GIT_URL} > /tmp/install.sh \
  && sudo chmod 755 /tmp/install.sh \
- && sudo /tmp/install.sh \
+ && sudo /tmp/install.sh ${ORG} ${BRANCH} ${BASE_BRANCH} \
  && sudo rm -rf /etc/puppet/modules/* /mnt/swapfile \
  && sudo yum clean all \
  && sudo rm -f /tmp/install.sh \

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ ORG=$1
 BRANCH=$2
 BASE_BRANCH=$3
 
-mods_dir=/etc/puppetlabs/code/modules
+mods_dir=/etc/puppet/modules
 mkdir -p $mods_dir
 cd $mods_dir
 

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
+set -e
 
-mods_dir=/etc/puppet/modules
+if [ "$#" -ne 3 ]; then
+  echo "Usage: $0 <github org> <branch> <base branch>"
+  echo "e.g.: $0 hysds master master"
+  echo "e.g.: $0 hysds python2 develop"
+  echo "e.g.: $0 pymonger python3 develop"
+  exit 1
+fi
+ORG=$1
+BRANCH=$2
+BASE_BRANCH=$3
+
+mods_dir=/etc/puppetlabs/code/modules
+mkdir -p $mods_dir
 cd $mods_dir
 
 ##########################################
@@ -59,13 +72,13 @@ fi
 # export hysds_base puppet module
 ##########################################
 
-git_loc="${git_url}/hysds/puppet-hysds_base"
+git_loc="${git_url}/${ORG}/puppet-hysds_base"
 mod_dir=$mods_dir/hysds_base
 site_pp=$mod_dir/site.pp
 
 # check that module is here; if not, export it
 if [ ! -d $mod_dir ]; then
-  $git_cmd clone $git_loc $mod_dir
+  $git_cmd clone --single-branch -b $BASE_BRANCH $git_loc $mod_dir
 fi
 
 
@@ -73,13 +86,13 @@ fi
 # export verdi puppet module
 ##########################################
 
-git_loc="${git_url}/hysds/puppet-verdi"
+git_loc="${git_url}/${ORG}/puppet-verdi"
 mod_dir=$mods_dir/verdi
 site_pp=$mod_dir/site.pp
 
 # check that module is here; if not, export it
 if [ ! -d $mod_dir ]; then
-  $git_cmd clone -b docker --single-branch $git_loc $mod_dir
+  $git_cmd clone --single-branch -b $BRANCH $git_loc $mod_dir
 fi
 
 
@@ -87,13 +100,13 @@ fi
 # export cont_int puppet module
 ##########################################
 
-git_loc="${git_url}/hysds/puppet-cont_int"
+git_loc="${git_url}/${ORG}/puppet-cont_int"
 mod_dir=$mods_dir/cont_int
 site_pp=$mod_dir/site.pp
 
 # check that module is here; if not, export it
 if [ ! -d $mod_dir ]; then
-  $git_cmd clone -b docker --single-branch $git_loc $mod_dir
+  $git_cmd clone --single-branch -b $BRANCH $git_loc $mod_dir
 fi
 
 
@@ -101,4 +114,10 @@ fi
 # apply
 ##########################################
 
-$puppet_cmd apply $site_pp
+PUPPET_EXIT_CODE=0
+$puppet_cmd apply --detailed-exitcodes $site_pp || PUPPET_EXIT_CODE=$?
+if [[ ("$PUPPET_EXIT_CODE" -ne 0 ) && ("$PUPPET_EXIT_CODE" -ne 2) ]]; then
+  echo "Puppet failed to run cleanly."
+  exit 1
+fi
+exit 0

--- a/install.sh
+++ b/install.sh
@@ -78,7 +78,7 @@ site_pp=$mod_dir/site.pp
 
 # check that module is here; if not, export it
 if [ ! -d $mod_dir ]; then
-  $git_cmd clone --single-branch -b $BASE_BRANCH $git_loc $mod_dir
+  $git_cmd clone --single-branch -b $BASE_BRANCH $git_loc $mod_dir --depth 1
 fi
 
 
@@ -92,7 +92,7 @@ site_pp=$mod_dir/site.pp
 
 # check that module is here; if not, export it
 if [ ! -d $mod_dir ]; then
-  $git_cmd clone --single-branch -b $BRANCH $git_loc $mod_dir
+  $git_cmd clone --single-branch -b $BRANCH $git_loc $mod_dir --depth 1
 fi
 
 
@@ -106,7 +106,7 @@ site_pp=$mod_dir/site.pp
 
 # check that module is here; if not, export it
 if [ ! -d $mod_dir ]; then
-  $git_cmd clone --single-branch -b $BRANCH $git_loc $mod_dir
+  $git_cmd clone --single-branch -b $BRANCH $git_loc $mod_dir --depth 1
 fi
 
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,7 +44,6 @@ class cont_int inherits verdi {
     mode    => 0644,
     content => template('cont_int/hudson.model.UpdateCenter.xml'),
     require => File["$jenkins_dir"],
-    notify  => Exec['daemon-reload'],
   }
 
 


### PR DESCRIPTION
Refactored code to allow building of CentOS and OracleLinux docker images automatically.

```
(base) MT-204713:swot-pcm mcayanan$ docker images | grep cont_int
hysds/cont_int        20220301          3c7924effddd   5 hours ago    3.31GB
hysds/cont_int        develop-centos7   3c7924effddd   5 hours ago    3.31GB

(base) MT-204713:swot-pcm mcayanan$ docker run -it hysds/cont_int:develop-centos7 /bin/bash
ssh-keygen: generating new host keys: RSA1 RSA DSA ECDSA ED25519 
ops@352f7e89e814:~$ more /etc/redhat-release 
CentOS Linux release 7.9.2009 (Core)
ops@352f7e89e814:~$ 
```
