### PR TITLE
HC-522-update: Updates to the Dockerfile and Manifest init to support moving away from the OPS user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.0-experimental
-ARG TAG=latest
+ARG TAG=HC-522
 FROM hysds/dev:${TAG}
 
 # get org and branch

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.0-experimental
-ARG TAG=HC-522-update
+ARG TAG=latest
 FROM hysds/dev:${TAG}
 
 # get org and branch

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,9 @@ ARG HYSDS_RELEASE=develop
 # add latest repo version to invalidate cache
 ADD https://api.github.com/repos/${ORG}/puppet-cont_int/git/refs/heads/${BRANCH} version.json
 
+# set HOME explicitly
+ENV HOME /home/ops
+
 # provision via puppet
 RUN --mount=type=secret,id=git_oauth_token sudo cp /run/secrets/git_oauth_token $HOME/.git_oauth_token \
  && sudo chown ops:ops $HOME/.git_oauth_token \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ ADD https://api.github.com/repos/${ORG}/puppet-cont_int/git/refs/heads/${BRANCH}
 
 # provision via puppet
 RUN --mount=type=secret,id=git_oauth_token sudo cp /run/secrets/git_oauth_token $HOME/.git_oauth_token \
- && sudo chown ops:ops $HOME/.git_oauth_token \
+ && sudo chown root:root $HOME/.git_oauth_token \
  && set -ex \
  && sudo dnf update -y \
  && sudo curl -skL ${GIT_URL} > /tmp/install.sh \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.0-experimental
-ARG TAG=HC-522
+ARG TAG=HC-522-update
 FROM hysds/dev:${TAG}
 
 # get org and branch
@@ -60,16 +60,16 @@ RUN set -ex \
  && sudo rm -f /tmp/install.sh \
  && sudo rm -rf /var/cache/dnf
 
-# copy ops home
-COPY --chown=ops:ops --from=0 /home/ops /home/ops
+# copy root
+COPY --chown=root:root --from=0 /root /root
 
 # link configs
 RUN set -ex \
- && ln -sf /home/ops/verdi/etc/celeryconfig.py /home/ops/verdi/ops/hysds/celeryconfig.py
+ && ln -sf $HOME/verdi/etc/celeryconfig.py $HOME/verdi/ops/hysds/celeryconfig.py
 
 # set default supervisord conf and copy includes
-COPY --chown=ops:ops docker/supervisord.conf /home/ops/verdi/etc/supervisord.conf
-COPY --chown=ops:ops docker/conf.d /home/ops/verdi/etc/conf.d
+COPY --chown=root:root docker/supervisord.conf $HOME/verdi/etc/supervisord.conf
+COPY --chown=root:root docker/conf.d $HOME/verdi/etc/conf.d
 
 # set entrypoint
 COPY docker/docker-entrypoint.sh /docker-entrypoint.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,9 +17,6 @@ ARG HYSDS_RELEASE=develop
 # add latest repo version to invalidate cache
 ADD https://api.github.com/repos/${ORG}/puppet-cont_int/git/refs/heads/${BRANCH} version.json
 
-# set HOME explicitly
-ENV HOME /home/ops
-
 # provision via puppet
 RUN --mount=type=secret,id=git_oauth_token sudo cp /run/secrets/git_oauth_token $HOME/.git_oauth_token \
  && sudo chown ops:ops $HOME/.git_oauth_token \

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,7 +8,7 @@ class cont_int inherits verdi {
   # jenkins directory
   #####################################################
 
-  $jenkins_dir = "/home/$user/jenkins"
+  $jenkins_dir = "/$user/jenkins"
 
 
   #####################################################


### PR DESCRIPTION
This PR updates the Dockerfile as well as the init.pp in the puppet manifest to support the moving away from the OPS user in the HySDS Core container. The containers will default to the root user now, where the HySDS Core code will now reside under `/root`.

For testing, the CircleCI was modified to build containers under the HC-522-update tag and it passed:

![image](https://github.com/user-attachments/assets/879e9278-c5f3-46fe-893c-b8859b16d6c9)


TODO: Will need to remove kludge once approved: https://github.com/hysds/puppet-cont_int/compare/docker...HC-522-update?expand=1#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcR2